### PR TITLE
Initial Refactor of Model/Store Handling

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
@@ -77,8 +77,16 @@ class YamlFileDriver extends AbstractFileDriver
     public function getOwnedTypes($type, array $types = [])
     {
         $all = $this->getAllTypeNames();
+
+        $path = $this->getFilePathForType($type);
+        $superMapping = $this->getMapping($type, $path);
+
+        $abstract = isset($superMapping['entity']['abstract']) && true === $superMapping['entity']['abstract'];
+
         foreach ($this->getAllTypeNames() as $searchType) {
-            if ($type === $searchType) {
+
+            if ($type === $searchType && false === $abstract) {
+                $types[] = $type;
                 continue;
             }
             if (0 !== strpos($searchType, $type)) {
@@ -92,7 +100,6 @@ class YamlFileDriver extends AbstractFileDriver
                 continue;
             }
             $types[] = $searchType;
-
         }
         return $types;
     }

--- a/src/Actinoids/Modlr/RestOdm/Models/Attributes.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/Attributes.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Models;
+
+use Actinoids\Modlr\RestOdm\Store\Store;
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Represents the attributes of a Model.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class Attributes
+{
+    private $original = [];
+
+    private $current = [];
+
+    private $remove = [];
+
+    public function __construct(array $original = [])
+    {
+        $this->original = $original;
+    }
+
+    public function intialize(array $original)
+    {
+        $this->rollback();
+        $this->original = $original;
+        return $this;
+    }
+
+    public function get($key)
+    {
+        if ($this->willRemove($key)) {
+            return null;
+        }
+        if (true === $this->willChange($key)) {
+            return $this->getCurrent($key);
+        }
+        return $this->getOriginal($key);
+    }
+
+    public function set($key, $value)
+    {
+        if (null === $value) {
+            return $this->remove($key);
+        }
+        $this->clearRemoval($key);
+
+        if ($value === $this->getOriginal($key)) {
+            $this->clearChange($key);
+        } else {
+            $this->current[$key] = $value;
+        }
+        return $this;
+    }
+
+    public function remove($key)
+    {
+        if (false === $this->willRemove($key)) {
+            $this->remove[] = $key;
+            $this->clearChange($key);
+        }
+        return $this;
+    }
+
+    public function rollback()
+    {
+        $this->current = [];
+        $this->remove = [];
+        return $this;
+    }
+
+    public function areDirty()
+    {
+        return !empty($this->current) || !empty($this->remove);
+    }
+
+    protected function clearRemoval($key)
+    {
+        if (false === $this->willRemove($key)) {
+            return $this;
+        }
+        $key = array_search($key, $this->remove);
+        unset($this->remove[$key]);
+        $this->remove = array_values($this->remove);
+        return $this;
+    }
+
+    protected function clearChange($key)
+    {
+        if (true === $this->willChange($key)) {
+            unset($this->current[$key]);
+        }
+        return $this;
+    }
+
+    protected function willRemove($key)
+    {
+        return in_array($key, $this->remove);
+    }
+
+    protected function willChange($key)
+    {
+        return null !== $this->getCurrent($key);
+    }
+
+    protected function getOriginal($key)
+    {
+        if (isset($this->original[$key])) {
+            return $this->original[$key];
+        }
+        return null;
+    }
+
+    protected function getCurrent($key)
+    {
+        if (isset($this->current[$key])) {
+            return $this->current[$key];
+        }
+        return null;
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Models/Model.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/Model.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Models;
+
+use Actinoids\Modlr\RestOdm\Store\Store;
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Represents a data record from a persistence (database) layer.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class Model
+{
+    /**
+     * The id value of this model.
+     * Always converted to a string when in the model context.
+     *
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * The Model's attributes
+     *
+     * @var Attributes
+     */
+    protected $attributes;
+
+    /**
+     * The model state, with default values.
+     *
+     * @var State
+     */
+    protected $state;
+
+    /**
+     * The EntityMetadata that defines this Model.
+     *
+     * @var EntityMetadata
+     */
+    protected $metadata;
+
+    /**
+     * The Model Store for handling lifecycle operations.
+     *
+     * @var Store
+     */
+    protected $store;
+
+    /**
+     * Constructor.
+     *
+     * @param   EntityMetadata  $metadata   The internal entity metadata that supports this Model.
+     * @param   string          $identifier The database identifier.
+     * @param   Store           $store      The model store service for handling persistence operations.
+     * @param   array           $properties The model's attributes and relationships as a flattened, keyed array.
+     */
+    public function __construct(EntityMetadata $metadata, $identifier, Store $store, array $data = [])
+    {
+        $this->metadata = $metadata;
+        $this->identifier = $identifier;
+        $this->store = $store;
+        $this->state = new State();
+        $this->initialize($data);
+    }
+
+    public function isDirty()
+    {
+        return $this->attributes->areDirty();
+    }
+
+    public function setAttribute($key, $value)
+    {
+        if (false === $this->getMetadata()->hasAttribute($key)) {
+            return $this;
+        }
+        $this->attributes->set($key, $value);
+        return $this;
+    }
+
+
+    /**
+     * @todo    This likely should be public. Anyone could set the state.
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    protected function initialize(array $data)
+    {
+        $meta = $this->getMetadata();
+        $attributes = [];
+        foreach ($data as $key => $value) {
+            if (false === $meta->hasAttribute($key)) {
+                continue;
+            }
+            $attributes[$key] = $value;
+        }
+        $this->attributes = new Attributes($attributes);
+        return $this;
+    }
+
+    public function setState($state, $bit = true)
+    {
+        if (!isset($this->state[$state])) {
+            throw new \RuntimeException(sprintf('The state "%s" is not valid.'));
+        }
+        $this->state[$state] = (Boolean) $bit;
+        return $this;
+    }
+
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getId()
+    {
+        return $this->identifier;
+    }
+
+     /**
+     * {@inheritDoc}
+     */
+    public function getType()
+    {
+        return $this->metadata->type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCompositeKey()
+    {
+        return sprintf('%s.%s', $this->getType(), $this->getId());
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Models/State.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/State.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Models;
+
+use Actinoids\Modlr\RestOdm\Store;
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Represents a data record from a persistence (database) layer.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class State
+{
+    private $status = [
+        'empty'     => false,
+        'loading'   => false,
+        'loaded'    => false,
+        'dirty'     => false,
+        'saving'    => false,
+        'deleted'   => false,
+        'new'       => false,
+    ];
+
+    public function __construct()
+    {
+        $this->setEmpty();
+    }
+
+    public function setNew()
+    {
+        $this->setLoaded();
+        $this->setDirty();
+        $this->set('new', true);
+    }
+
+    public function setLoaded($bit = true)
+    {
+        $this->setEmpty(false);
+        $this->set('loaded', $bit);
+    }
+
+    public function setDirty($bit = true)
+    {
+        $this->set('dirty', $bit);
+    }
+
+    public function setEmpty($bit = true)
+    {
+        $this->set('empty', $bit);
+    }
+
+    protected function set($key, $bit)
+    {
+        $this->status[$key] = (Boolean) $bit;
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/MongoDBPersister.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/MongoDBPersister.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister;
+
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+use Doctrine\MongoDB\Connection;
+use \MongoId;
+
+/**
+ * Persists and retrieves models to/from a MongoDB database.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class MongoDBPersister implements PersisterInterface
+{
+    const IDENTIFIER_KEY = '_id';
+    const POLYMORPHIC_KEY = '_type';
+
+    /**
+     * The Doctine MongoDB connection.
+     *
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * Constructor.
+     *
+     * @param   Connection          $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieve(EntityMetadata $metadata, $identifier)
+    {
+        $criteria = $this->getRetrieveCritiera($metadata, $identifier);
+        $result = $this->createQueryBuilder($metadata)
+            ->find()
+            ->setQueryArray($criteria)
+            ->getQuery()
+            ->execute()
+            ->getSingleResult()
+        ;
+        if (null === $result) {
+            return;
+        }
+        return $this->hydrateRecord($metadata, $result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generateId($strategy = null)
+    {
+        if (false === $this->isIdStrategySupported($strategy)) {
+            throw PersisterException::nyi('ID generation currently only supports an object strategy, or none at all.');
+        }
+        return new MongoId();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function convertId($identifier, $strategy = null)
+    {
+        if (false === $this->isIdStrategySupported($strategy)) {
+            throw PersisterException::nyi('ID conversion currently only supports an object strategy, or none at all.');
+        }
+        return new MongoId($identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierKey()
+    {
+        return self::IDENTIFIER_KEY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPolymorphicKey()
+    {
+        return self::POLYMORPHIC_KEY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extractType(EntityMetadata $metadata, array $data)
+    {
+        if (false === $metadata->isPolymorphic()) {
+            return $metadata->type;
+        }
+        if (!isset($data[$this->getPolymorphicKey()])) {
+            throw PersisterException::badRequest(sprintf('Unable to extract polymorphic type. The "%s" key was not found.', $this->getPolymorphicKey()));
+        }
+        return $data[$this->getPolymorphicKey()];
+    }
+
+    /**
+     * Processes raw MongoDB data an converts it into a standardized Record object.
+     *
+     * @param   EntityMetadata  $metadata
+     * @param   array           $data
+     * @return  Record
+     */
+    protected function hydrateRecord(EntityMetadata $metadata, array $data)
+    {
+        $identifier = $data[$this->getIdentifierKey()];
+        unset($data[$this->getIdentifierKey()]);
+
+        $type = $this->extractType($metadata, $data);
+        unset($data[$this->getPolymorphicKey()]);
+
+        return new Record($type, $identifier, $data);
+    }
+
+    /**
+     * Gets standard database retrieval criteria for an entity and the provided identifiers.
+     *
+     * @param   EntityMetadata  $metadata       The entity to retrieve database records for.
+     * @param   string|array    $identifiers    The IDs to query.
+     * @return  array
+     */
+    protected function getRetrieveCritiera(EntityMetadata $metadata, $identifiers)
+    {
+        $criteria = [$this->getIdentifierKey() => null];
+        if (is_array($identifiers) && !empty($identifiers)) {
+            $ids = [];
+            foreach ($identifiers as $id) {
+                $ids[] = $this->convertId($id);
+            }
+            $criteria[$this->getIdentifierKey()] = ['$in' => $ids];
+        } else {
+            $criteria[$this->getIdentifierKey()] = $this->convertId($identifiers);
+        }
+        if (true === $metadata->isChildEntity()) {
+            $criteria[$this->getPolymorphicKey()] = $metadata->type;
+        }
+        return $criteria;
+    }
+
+    /**
+     * Creates a builder object for querying MongoDB based on the provided metadata.
+     *
+     * @todo    The database and collection names should not exist on the root of the metadata.
+     * @todo    Eventually, a persiter metadata object should be used, that's db specific, to provide this.
+     * @param   EntityMetadata  $metadata
+     * @return  \Doctrine\MongoDB\Query\Builder
+     */
+    protected function createQueryBuilder(EntityMetadata $metadata)
+    {
+        $collection = $this->connection->selectCollection($metadata->db, $metadata->collection);
+        return $collection->createQueryBuilder();
+    }
+
+    /**
+     * Determines if the current id strategy is supported.
+     *
+     * @param   string|null     $strategy
+     * @return  bool
+     */
+    protected function isIdStrategySupported($strategy)
+    {
+        return (null === $strategy || 'object' === $strategy);
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Store;
+
+use Actinoids\Modlr\RestOdm\Exception\AbstractHttpException;
+
+/**
+ * Persister exceptions.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class PersisterException extends AbstractHttpException
+{
+    public static function recordNotFound($type, $identifer)
+    {
+        return new self(
+            sprintf(
+                'No record was found for "%s" using id "%s"',
+                $type,
+                $identifer
+            ),
+            404,
+            __FUNCTION__
+        );
+    }
+
+    public static function badRequest($message = null)
+    {
+        return new self(
+            sprintf(
+                'Oops! We were unable to handle database operations for this record. %s',
+                $message
+            ),
+            500,
+            __FUNCTION__
+        );
+    }
+
+    public static function nyi($featureDescription)
+    {
+        return new self(
+            sprintf(
+                'Oops! A feature was accessed that is currently unimplemented: %s',
+                $featureDescription
+            ),
+            500,
+            __FUNCTION__
+        );
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister;
+
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Defines the persister service implementation for persisting modals to a database layer.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+interface PersisterInterface
+{
+    /**
+     * Retrieves a single model record from the database.
+     *
+     * @param   EntityMetadata  $metadata   The metadata for the model/record.
+     * @param   string          $identifier The identifier for the record. Always a string. The persister must convert.
+     * @return  Record|null
+     */
+    public function retrieve(EntityMetadata $metadata, $identifier);
+
+    /**
+     * Gets the identifier field key name for this database.
+     *
+     * @return  string
+     */
+    public function getIdentifierKey();
+
+    /**
+     * Gets the polymorphic field key name for this database.
+     *
+     * @return  string
+     */
+    public function getPolymorphicKey();
+
+    /**
+     * Extracts the model type based on raw database data.
+     * Is needed to determine the proper polymorphic type, where applicable.
+     *
+     * @param   EntityMetadata  $metadata
+     * @param   array           $data
+     * @return  string
+     * @throws  PersisterException If the type cannot be extracted/found on the raw record data.
+     */
+    public function extractType(EntityMetadata $metadata, array $data);
+
+    /**
+     * Generates a new persistence level identifier based on the (optional) generation strategy.
+     *
+     * @param   string|null     $strategy   The generation strategy, if provided.
+     * @return  mixed
+     */
+    public function generateId($strategy = null);
+
+    /**
+     * Converts a stringified store level identifier into a persistence level identifier.
+     * Is based on the (optional) generation strategy.
+     *
+     * @param   string      $identifier The stringified identifier to convert.
+     * @param   string|null $strategy   The generation strategy, if provided.
+     * @return  mixed
+     */
+    public function convertId($identifier, $strategy = null);
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/Record.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/Record.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister;
+
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Persists and retrieves models to/from a MongoDB database.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class Record
+{
+    private $id;
+
+    private $type;
+
+    private $properties = [];
+
+    public function __construct($type, $id, array $properties)
+    {
+        $this->type = $type;
+        $this->id = (String) $id;
+        $this->properties = $properties;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Store/Store.php
+++ b/src/Actinoids/Modlr/RestOdm/Store/Store.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Store;
+
+use Actinoids\Modlr\RestOdm\Models\Model;
+use Actinoids\Modlr\RestOdm\Metadata\MetadataFactory;
+use Actinoids\Modlr\RestOdm\Persister\PersisterInterface;
+use Actinoids\Modlr\RestOdm\Persister\Record;
+
+/**
+ * Manages models and their persistence.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class Store
+{
+    private $mf;
+
+    private $persister;
+
+    private $identityMap = [];
+
+    public function __construct(MetadataFactory $mf, PersisterInterface $persister)
+    {
+        $this->mf = $mf;
+        $this->persister = $persister;
+    }
+
+    /**
+     * Finds a single record from the persistence layer, by type and id.
+     * Will return a Model object if found, or throw an exception if not.
+     *
+     * @api
+     * @param   string      $typeKey    The model type.
+     * @param   string      $identifier The model id.
+     * @param   bool        $reload     Whether to force a reload.
+     * @return  Model
+     * @throws  StoreException If the record cannot be found from the persistence layer.
+     */
+    public function findRecord($typeKey, $identifier, $reload = false)
+    {
+        if (true === $this->inIdentityMap($typeKey, $identifier) && false === $reload) {
+            return $this->getFromIdentityMap($typeKey, $identifier);
+        }
+
+        $persister = $this->getPersisterFor($typeKey);
+        $record = $persister->retrieve($this->getMetadataForType($typeKey), $identifier);
+        if (null === $record) {
+            throw StoreException::recordNotFound($type, $identifier);
+        }
+        return $this->load($typeKey, $record);
+    }
+
+    public function createRecord($typeKey, $identifier = null, array $data = [])
+    {
+        if (empty($identifier)) {
+            $identifier = $this->generateIdentifier($typeKey);
+        }
+        return $this->createModel($typeKey, $identifier, $data);
+    }
+
+    protected function load($typeKey, Record $record)
+    {
+        $this->mf->validateResourceTypes($typeKey, $record->getType());
+        if (true === $this->inIdentityMap($record->getType(), $record->getId())) {
+            // Safety in case findRecord is called multiple times for the same record while it's already loaded.
+            return $this->getFromIdentityMap($record->getType(), $record->getId());
+        }
+        // Must use the type from the record to cover polymorphic models.
+        $metadata = $this->getMetadataForType($record->getType());
+        $model = new Model($metadata, $record->getId(), $this, $record->getProperties());
+        $model->getState()->setLoaded();
+        $this->pushIdentityMap($model);
+        return $model;
+    }
+
+    /**
+     * Determines the persister to use for the provided model key.
+     *
+     * @todo    The persister should NOT be injected directly, but should have a persister manager service.
+     * @todo    Instead, a persister should be chosen based on the metadata for the provided type.
+     * @todo    Should throw an exception if persister metadata was unable to be found, or the service doesn't exist.
+     * @param   string  $typeKey    The model type key.
+     * @return  PersisterInterface
+     */
+    protected function getPersisterFor($typeKey)
+    {
+        return $this->persister;
+    }
+
+    protected function generateIdentifier($typeKey)
+    {
+        return $this->getPersisterFor($typeKey)->generateId();
+    }
+
+
+
+    public function getMetadataForType($typeKey)
+    {
+        return $this->mf->getMetadataForType($typeKey);
+    }
+
+
+
+    protected function createModel($typeKey, $identifier, array $data = [])
+    {
+        if (true === $this->inIdentityMap($typeKey, $identifier)) {
+            throw new \RuntimeException(sprintf('A model is already loaded for type "%s" using identifier "%s"', $typeKey, $identifier));
+        }
+        $metadata = $this->getMetadataForType($typeKey);
+        if (true === $metadata->isAbstract()) {
+            throw StoreException::badRequest('Abstract models cannot be created directly. You must instantiate a child class');
+        }
+        $model = new Model($metadata, $identifier, $this, $data);
+        $model->getState()->setNew();
+        $this->pushIdentityMap($model);
+        return $model;
+    }
+
+    protected function getIdentityMapForType($typeKey)
+    {
+        if (isset($this->identityMap[$typeKey])) {
+            return $this->identityMap[$typeKey];
+        }
+        return [];
+    }
+
+    protected function getFromIdentityMap($typeKey, $identifier)
+    {
+        $map = $this->getIdentityMapForType($typeKey);
+        if (isset($map[$identifier])) {
+            return $map[$identifier];
+        }
+        return null;
+    }
+
+    protected function pushIdentityMap(Model $model)
+    {
+        $this->identityMap[$model->getType()][$model->getId()] = $model;
+        return $this;
+    }
+
+    public function inIdentityMap($typeKey, $identifier)
+    {
+        return null !== $this->getFromIdentityMap($typeKey, $identifier);
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Store/StoreException.php
+++ b/src/Actinoids/Modlr/RestOdm/Store/StoreException.php
@@ -28,7 +28,7 @@ class StoreException extends AbstractHttpException
     {
         return new self(
             sprintf(
-                'Oops! We were unable to handle database operations for this record. %s',
+                'Oops! We were unable to handle store operations for this record. %s',
                 $message
             ),
             500,


### PR DESCRIPTION
The "power" of the model has now been moved into the model itself. The store is now database agnostic, and relies on a persister. 

This functionality will also allow us to use models natively in PHP, not just via REST.