### PR TITLE
Create, delete, and update support.

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Models/Attributes.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/Attributes.php
@@ -12,24 +12,43 @@ use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
  */
 class Attributes
 {
+    /**
+     * The original attribute values.
+     *
+     * @var array
+     */
     private $original = [];
 
+    /**
+     * The current/modified attribute values.
+     *
+     * @var array
+     */
     private $current = [];
 
+    /**
+     * Any attributes that have been flagged for removal.
+     *
+     * @var array
+     */
     private $remove = [];
 
+    /**
+     * Constructor.
+     *
+     * @param   array   $original   Any original attributes to apply.
+     */
     public function __construct(array $original = [])
     {
         $this->original = $original;
     }
 
-    public function intialize(array $original)
-    {
-        $this->rollback();
-        $this->original = $original;
-        return $this;
-    }
-
+    /**
+     * Gets the current value of an attribute.
+     *
+     * @param   string  $key    The attribute key.
+     * @return  mixed
+     */
     public function get($key)
     {
         if ($this->willRemove($key)) {
@@ -41,6 +60,13 @@ class Attributes
         return $this->getOriginal($key);
     }
 
+    /**
+     * Sets a new value to an attribute.
+     *
+     * @param   string  $key    The attribute key.
+     * @param   mixed   $value  The value to set.
+     * @return  mixed
+     */
     public function set($key, $value)
     {
         if (null === $value) {
@@ -56,15 +82,28 @@ class Attributes
         return $this;
     }
 
+    /**
+     * Sets a new value to an attribute.
+     *
+     * @param   string  $key    The attribute key.
+     * @return  self
+     */
     public function remove($key)
     {
         if (false === $this->willRemove($key)) {
-            $this->remove[] = $key;
             $this->clearChange($key);
+            if (true === $this->hasOriginal($key)) {
+                $this->remove[] = $key;
+            }
         }
         return $this;
     }
 
+    /**
+     * Rolls back the attributes to their original state.
+     *
+     * @return  self
+     */
     public function rollback()
     {
         $this->current = [];
@@ -72,11 +111,58 @@ class Attributes
         return $this;
     }
 
+    /**
+     * Replaces the current attributes with new ones.
+     * Will revert/rollback any current changes.
+     *
+     * @param   array   $original
+     * @return  self
+     */
+    public function replace(array $original)
+    {
+        $this->rollback();
+        $this->original = $original;
+        return $this;
+    }
+
+
+    /**
+     * Deteremines if the attributes have different values from their original state.
+     *
+     * @return  bool
+     */
     public function areDirty()
     {
         return !empty($this->current) || !empty($this->remove);
     }
 
+    /**
+     * Calculates any attribute changes.
+     *
+     * @return  array
+     */
+    public function calculateChangeSet()
+    {
+        $set = [];
+        foreach ($this->current as $key => $current) {
+            $original = isset($this->original[$key]) ? $this->original[$key] : null;
+            $set[$key]['old'] = $original;
+            $set[$key]['new'] = $current;
+        }
+        foreach ($this->remove as $key) {
+            $set[$key]['old'] = $this->original[$key];
+            $set[$key]['new'] = null;
+        }
+        ksort($set);
+        return $set;
+    }
+
+    /**
+     * Clears an attribute from the removal queue.
+     *
+     * @param   string  $key    The field key.
+     * @return  self
+     */
     protected function clearRemoval($key)
     {
         if (false === $this->willRemove($key)) {
@@ -88,6 +174,12 @@ class Attributes
         return $this;
     }
 
+    /**
+     * Clears an attribute as having been changed.
+     *
+     * @param   string  $key    The field key.
+     * @return  self
+     */
     protected function clearChange($key)
     {
         if (true === $this->willChange($key)) {
@@ -96,16 +188,45 @@ class Attributes
         return $this;
     }
 
+    /**
+     * Determines if an attribute is in the removal queue.
+     *
+     * @param   string  $key    The field key.
+     * @return  bool
+     */
     protected function willRemove($key)
     {
         return in_array($key, $this->remove);
     }
 
+    /**
+     * Determines if an attribute has a new value.
+     *
+     * @param   string  $key    The field key.
+     * @return  bool
+     */
     protected function willChange($key)
     {
         return null !== $this->getCurrent($key);
     }
 
+    /**
+     * Determines if an attribute has an original value.
+     *
+     * @param   string  $key    The field key.
+     * @return  bool
+     */
+    protected function hasOriginal($key)
+    {
+        return null !== $this->getOriginal($key);
+    }
+
+    /**
+     * Gets the attribute's original value.
+     *
+     * @param   string  $key    The field key.
+     * @return  mixed
+     */
     protected function getOriginal($key)
     {
         if (isset($this->original[$key])) {
@@ -114,6 +235,12 @@ class Attributes
         return null;
     }
 
+    /**
+     * Gets the attribute's current value.
+     *
+     * @param   string  $key    The field key.
+     * @return  mixed
+     */
     protected function getCurrent($key)
     {
         if (isset($this->current[$key])) {

--- a/src/Actinoids/Modlr/RestOdm/Models/Model.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/Model.php
@@ -28,7 +28,7 @@ class Model
     protected $attributes;
 
     /**
-     * The model state, with default values.
+     * The model state.
      *
      * @var State
      */
@@ -56,61 +56,166 @@ class Model
      * @param   Store           $store      The model store service for handling persistence operations.
      * @param   array           $properties The model's attributes and relationships as a flattened, keyed array.
      */
-    public function __construct(EntityMetadata $metadata, $identifier, Store $store, array $data = [])
+    public function __construct(EntityMetadata $metadata, $identifier, Store $store, array $properties = [])
     {
         $this->metadata = $metadata;
         $this->identifier = $identifier;
         $this->store = $store;
         $this->state = new State();
-        $this->initialize($data);
+        $this->initialize($properties);
     }
 
-    public function isDirty()
-    {
-        return $this->attributes->areDirty();
-    }
-
-    public function setAttribute($key, $value)
+    /**
+     * Sets an attribute value.
+     * Will do a dirty check immediately after setting.
+     *
+     * @todo    Handle data type conversion. Should this happen here?
+     * @param   string  $key    The attribute key (field) name.
+     * @param   mixed   $value  The value to apply.
+     * @return  self
+     */
+    public function attribute($key, $value)
     {
         if (false === $this->getMetadata()->hasAttribute($key)) {
             return $this;
         }
         $this->attributes->set($key, $value);
+        $this->state->setDirty($this->isDirty());
         return $this;
     }
 
-
     /**
-     * @todo    This likely should be public. Anyone could set the state.
+     * Saves the model.
+     *
+     * @return  self
      */
-    public function getState()
+    public function save()
     {
-        return $this->state;
+        if (true === $this->getState()->is('deleted')) {
+            return $this;
+        }
+        $this->store->commit($this);
+        return $this;
     }
 
-    protected function initialize(array $data)
+    /**
+     * Rolls back a model to its original, database values.
+     *
+     * @todo    Implement relationship rollbacks.
+     * @return  self
+     */
+    public function rollback()
+    {
+        $this->attributes->rollback();
+        return $this;
+    }
+
+    /**
+     * Reloads the model from the database.
+     *
+     * @return  self
+     */
+    public function reload()
+    {
+        if (true === $this->getState()->is('deleted')) {
+            return $this;
+        }
+        $record = $this->store->retrieveRecord($this->getType(), $this->getId());
+        $this->initialize($record->getProperties());
+        return $this;
+    }
+
+    /**
+     * Restores an in-memory deleted object back to the database.
+     *
+     * @todo    Implement if needed. Or should restore clear a pending delete?
+     * @return  self
+     */
+    public function restore()
+    {
+        return $this;
+    }
+
+    /**
+     * Marks the record for deletion.
+     * Will not remove from the database until $this->save() is called.
+     *
+     * @return  self
+     * @throws  \RuntimeException   If a new (unsaved) model is deleted.
+     */
+    public function delete()
+    {
+        if (true === $this->getState()->is('new')) {
+            throw new \RuntimeException('You cannot delete a new model');
+        }
+        if (true === $this->getState()->is('deleted')) {
+            return $this;
+        }
+        $this->getState()->setDeleting();
+        return $this;
+    }
+
+    /**
+     * Initializes the modal and loads it's attributes and relationships.
+     *
+     * @todo    Add relationship support.
+     * @param   array   $properties     The record attributes and relationships to apply.
+     * @return  self
+     */
+    protected function initialize(array $properties)
     {
         $meta = $this->getMetadata();
         $attributes = [];
-        foreach ($data as $key => $value) {
+        foreach ($properties as $key => $value) {
             if (false === $meta->hasAttribute($key)) {
                 continue;
             }
             $attributes[$key] = $value;
         }
         $this->attributes = new Attributes($attributes);
+        $this->state->setDirty($this->isDirty());
         return $this;
     }
 
-    public function setState($state, $bit = true)
+    /**
+     * Determines if the model is currently dirty.
+     * Checks against the attribute and relationship dirty states.
+     *
+     * @todo    Implement relationships.
+     * @return  bool
+     */
+    public function isDirty()
     {
-        if (!isset($this->state[$state])) {
-            throw new \RuntimeException(sprintf('The state "%s" is not valid.'));
-        }
-        $this->state[$state] = (Boolean) $bit;
-        return $this;
+        return $this->attributes->areDirty();
     }
 
+    /**
+     * Gets the current change set of attributes and relationships.
+     *
+     * @todo    Implement relationship changeset.
+     * @return  array
+     */
+    public function getChangeSet()
+    {
+        return $this->attributes->calculateChangeSet();
+    }
+
+    /**
+     * Gets the model state object.
+     *
+     * @todo    Should this be public? State setting should likely be locked from the outside world.
+     * @return  State
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Gets the metadata for this model.
+     *
+     * @return  EntityMetadata
+     */
     public function getMetadata()
     {
         return $this->metadata;

--- a/src/Actinoids/Modlr/RestOdm/Models/State.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/State.php
@@ -14,10 +14,9 @@ class State
 {
     private $status = [
         'empty'     => false,
-        'loading'   => false,
         'loaded'    => false,
         'dirty'     => false,
-        'saving'    => false,
+        'deleting'  => false,
         'deleted'   => false,
         'new'       => false,
     ];
@@ -27,11 +26,29 @@ class State
         $this->setEmpty();
     }
 
-    public function setNew()
+    public function is($status)
+    {
+        return $this->status[$status];
+    }
+
+    public function setDeleted($bit = true)
+    {
+        $this->set('deleted', $bit);
+        if ($this->is('deleted')) {
+            $this->setDeleting(false);
+            $this->setDirty(false);
+        }
+    }
+
+    public function setDeleting($bit = true)
+    {
+        $this->set('deleting', $bit);
+    }
+
+    public function setNew($bit = true)
     {
         $this->setLoaded();
-        $this->setDirty();
-        $this->set('new', true);
+        $this->set('new', $bit);
     }
 
     public function setLoaded($bit = true)

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
@@ -2,6 +2,7 @@
 
 namespace Actinoids\Modlr\RestOdm\Persister;
 
+use Actinoids\Modlr\RestOdm\Models\Model;
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 
 /**
@@ -19,6 +20,30 @@ interface PersisterInterface
      * @return  Record|null
      */
     public function retrieve(EntityMetadata $metadata, $identifier);
+
+    /**
+     * Creates a new database record from a model instance.
+     *
+     * @param   Model   $model
+     * @return  Model
+     */
+    public function create(Model $model);
+
+    /**
+     * Updates an existing database record from a model instance.
+     *
+     * @param   Model   $model
+     * @return  Model
+     */
+    public function update(Model $model);
+
+    /**
+     * Deletes a database record.
+     *
+     * @param   Model   $model
+     * @return  Model
+     */
+    public function delete(Model $model);
 
     /**
      * Gets the identifier field key name for this database.

--- a/src/Actinoids/Modlr/RestOdm/Store/Store.php
+++ b/src/Actinoids/Modlr/RestOdm/Store/Store.php
@@ -14,12 +14,33 @@ use Actinoids\Modlr\RestOdm\Persister\Record;
  */
 class Store
 {
+    /**
+     * @var MetadataFactory
+     */
     private $mf;
 
+    /**
+     * The persister for retrieve and saving records to the database layer.
+     *
+     * @todo Eventually this should be replaced by a persister manager and not injected directly.
+     * @var  PersisterInterface
+     */
     private $persister;
 
+    /**
+     * The identity map.
+     * Contains all models currently loaded in memory.
+     *
+     * @var array
+     */
     private $identityMap = [];
 
+    /**
+     * Constructor.
+     *
+     * @param   MetadataFactory     $mf
+     * @param   PersisterInterface  $persister
+     */
     public function __construct(MetadataFactory $mf, PersisterInterface $persister)
     {
         $this->mf = $mf;
@@ -31,47 +52,156 @@ class Store
      * Will return a Model object if found, or throw an exception if not.
      *
      * @api
-     * @param   string      $typeKey    The model type.
-     * @param   string      $identifier The model id.
-     * @param   bool        $reload     Whether to force a reload.
+     * @param   string  $typeKey    The model type.
+     * @param   string  $identifier The model id.
      * @return  Model
-     * @throws  StoreException If the record cannot be found from the persistence layer.
      */
-    public function findRecord($typeKey, $identifier, $reload = false)
+    public function find($typeKey, $identifier)
     {
-        if (true === $this->inIdentityMap($typeKey, $identifier) && false === $reload) {
+        if (true === $this->inIdentityMap($typeKey, $identifier)) {
             return $this->getFromIdentityMap($typeKey, $identifier);
         }
-
-        $persister = $this->getPersisterFor($typeKey);
-        $record = $persister->retrieve($this->getMetadataForType($typeKey), $identifier);
-        if (null === $record) {
-            throw StoreException::recordNotFound($type, $identifier);
-        }
-        return $this->load($typeKey, $record);
+        $record = $this->retrieveRecord($typeKey, $identifier);
+        return $this->loadModel($typeKey, $record);
     }
 
-    public function createRecord($typeKey, $identifier = null, array $data = [])
+    /**
+     * Creates a new record.
+     * The model will not be comitted to the persistence layer until $model->save() is called.
+     *
+     * @api
+     * @param   string      $typeKey    The model type.
+     * @param   string|null $identifier The model identifier. Generally should be null unless client-side id generation is in place.
+     * @param   array       $properties Any key/value properties to initalize the new record with.
+     * @return  Model
+     */
+    public function create($typeKey, $identifier = null, array $properties = [])
     {
         if (empty($identifier)) {
             $identifier = $this->generateIdentifier($typeKey);
         }
-        return $this->createModel($typeKey, $identifier, $data);
+        return $this->createModel($typeKey, $identifier, $properties);
     }
 
-    protected function load($typeKey, Record $record)
+    /**
+     * Deletes a model.
+     * The moel will be immediately deleted once retrieved.
+     *
+     * @api
+     * @param   string      $typeKey    The model type.
+     * @param   string|null $identifier The model identifier.
+     * @return  Model
+     */
+    public function delete($typeKey, $identifier)
+    {
+        $model = $this->find($typeKey, $identifier);
+        return $model->delete()->save();
+    }
+
+    /**
+     * Retrieves a Record object from the persistence layer.
+     *
+     * @param   string  $typeKey    The model type.
+     * @param   string  $identifier The model identifier.
+     * @return  Record
+     * @throws  StoreException  If the record cannot be found.
+     */
+    public function retrieveRecord($typeKey, $identifier)
+    {
+        $persister = $this->getPersisterFor($typeKey);
+        $record = $persister->retrieve($this->getMetadataForType($typeKey), $identifier);
+        if (null === $record) {
+            throw StoreException::recordNotFound($typeKey, $identifier);
+        }
+        return $record;
+    }
+
+    /**
+     * Loads/creates a model from a persistence layer Record.
+     *
+     * @param   string  $typeKey    The model type.
+     * @param   Record  $record     The persistence layer record.
+     * @return  Model
+     */
+    protected function loadModel($typeKey, Record $record)
     {
         $this->mf->validateResourceTypes($typeKey, $record->getType());
-        if (true === $this->inIdentityMap($record->getType(), $record->getId())) {
-            // Safety in case findRecord is called multiple times for the same record while it's already loaded.
-            return $this->getFromIdentityMap($record->getType(), $record->getId());
-        }
         // Must use the type from the record to cover polymorphic models.
         $metadata = $this->getMetadataForType($record->getType());
+
         $model = new Model($metadata, $record->getId(), $this, $record->getProperties());
         $model->getState()->setLoaded();
         $this->pushIdentityMap($model);
         return $model;
+    }
+
+    /**
+     * Creates a new Model instance.
+     * Will not be persisted until $model->save() is called.
+     *
+     * @param   string  $typeKey    The model type.
+     * @param   string  $identifier The model identifier.
+     * @param   array   $properties Any key/value properties to initalize the new record with.
+     */
+    protected function createModel($typeKey, $identifier, array $properties = [])
+    {
+        if (true === $this->inIdentityMap($typeKey, $identifier)) {
+            throw new \RuntimeException(sprintf('A model is already loaded for type "%s" using identifier "%s"', $typeKey, $identifier));
+        }
+        $metadata = $this->getMetadataForType($typeKey);
+        if (true === $metadata->isAbstract()) {
+            throw StoreException::badRequest('Abstract models cannot be created directly. You must instantiate a child class');
+        }
+        $model = new Model($metadata, $identifier, $this, $properties);
+        $model->getState()->setNew();
+        $this->pushIdentityMap($model);
+        return $model;
+    }
+
+    /**
+     * Commits a model by persisting it to the database.
+     *
+     * @todo    Eventually we'll want to schedule models and allow for mutiple commits, flushes, etc.
+     * @todo    Will need to handle cascade saving of new or modified relationships??
+     * @param   Model   $model  The model to commit.
+     * @return  Model
+     */
+    public function commit(Model $model)
+    {
+        if (false === $this->shouldCommit($model)) {
+            return $model;
+        }
+        $persister = $this->getPersisterFor($model->getType());
+        if (true === $model->getState()->is('new')) {
+            $persister->create($model);
+            $model->getState()->setNew(false);
+            // Should the model always reload? Or should the commit be assumed correct and just clear the new/dirty state?
+            $model->reload();
+        } elseif (true === $model->getState()->is('deleting')) {
+            // Deletes must execute before updates to prevent an update then a delete.
+            $persister->delete($model);
+            $model->getState()->setDeleted();
+        } elseif (true === $model->getState()->is('dirty')) {
+            $persister->update($model);
+            // Should the model always reload? Or should the commit be assumed correct and just clear the new/dirty state?
+            $model->reload();
+        } else {
+            throw new \RuntimeException('Unable to commit model.');
+        }
+        return $model;
+    }
+
+    /**
+     * Determines if a model is eligible for commit.
+     *
+     * @todo    Does delete need to be here?
+     * @param   Model   $model
+     * @return  bool
+     */
+    protected function shouldCommit(Model $model)
+    {
+        $state = $model->getState();
+        return true === $state->is('dirty') || $state->is('new') || $state->is('deleting');
     }
 
     /**
@@ -88,34 +218,28 @@ class Store
         return $this->persister;
     }
 
+    /**
+     * Generates a new identifier value for a model type.
+     *
+     * @param   string  $typeKey    The model type.
+     * @return  string
+     */
     protected function generateIdentifier($typeKey)
     {
-        return $this->getPersisterFor($typeKey)->generateId();
+        return (String) $this->getPersisterFor($typeKey)->generateId();
     }
 
-
-
+    /**
+     * Gets the metadata for a model type.
+     *
+     * @param   string  $typeKey    The model type.
+     * @return  EntityMetadata
+     */
     public function getMetadataForType($typeKey)
     {
         return $this->mf->getMetadataForType($typeKey);
     }
 
-
-
-    protected function createModel($typeKey, $identifier, array $data = [])
-    {
-        if (true === $this->inIdentityMap($typeKey, $identifier)) {
-            throw new \RuntimeException(sprintf('A model is already loaded for type "%s" using identifier "%s"', $typeKey, $identifier));
-        }
-        $metadata = $this->getMetadataForType($typeKey);
-        if (true === $metadata->isAbstract()) {
-            throw StoreException::badRequest('Abstract models cannot be created directly. You must instantiate a child class');
-        }
-        $model = new Model($metadata, $identifier, $this, $data);
-        $model->getState()->setNew();
-        $this->pushIdentityMap($model);
-        return $model;
-    }
 
     protected function getIdentityMapForType($typeKey)
     {
@@ -123,6 +247,14 @@ class Store
             return $this->identityMap[$typeKey];
         }
         return [];
+    }
+
+    protected function removeFromIdentityMap($typeKey, $identifier)
+    {
+        if (isset($this->identityMap[$typeKey][$identifier])) {
+            unset($this->identityMap[$typeKey][$identifier]);
+        }
+        return $this;
     }
 
     protected function getFromIdentityMap($typeKey, $identifier)


### PR DESCRIPTION
Full CRUD is now operational for attributes at the persistence/store level under the new Model/Store structure.