### PR TITLE
Fix polymorphism issue from persistence layer

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
@@ -2,6 +2,7 @@
 
 namespace Actinoids\Modlr\RestOdm\Persister;
 
+use Actinoids\Modlr\RestOdm\Store\Store;
 use Actinoids\Modlr\RestOdm\Models\Model;
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 
@@ -20,7 +21,7 @@ interface PersisterInterface
      * @param   array           $identifiers
      * @return  Record[]
      */
-    public function all(EntityMetadata $metadata, array $identifiers = []);
+    public function all(EntityMetadata $metadata, array $identifiers = [], Store $store);
 
     /**
      * Retrieves a single model record from the database.
@@ -29,7 +30,7 @@ interface PersisterInterface
      * @param   string          $identifier The identifier for the record. Always a string. The persister must convert.
      * @return  Record|null
      */
-    public function retrieve(EntityMetadata $metadata, $identifier);
+    public function retrieve(EntityMetadata $metadata, $identifier, Store $store);
 
     /**
      * Creates a new database record from a model instance.

--- a/src/Actinoids/Modlr/RestOdm/Store/Store.php
+++ b/src/Actinoids/Modlr/RestOdm/Store/Store.php
@@ -141,7 +141,7 @@ class Store
     public function retrieveRecord($typeKey, $identifier)
     {
         $persister = $this->getPersisterFor($typeKey);
-        $record = $persister->retrieve($this->getMetadataForType($typeKey), $identifier);
+        $record = $persister->retrieve($this->getMetadataForType($typeKey), $identifier, $this);
         if (null === $record) {
             throw StoreException::recordNotFound($typeKey, $identifier);
         }
@@ -159,7 +159,7 @@ class Store
     public function retrieveRecords($typeKey, array $identifiers)
     {
         $persister = $this->getPersisterFor($typeKey);
-        return $persister->all($this->getMetadataForType($typeKey), $identifiers);
+        return $persister->all($this->getMetadataForType($typeKey), $identifiers, $this);
     }
 
     /**


### PR DESCRIPTION
Hydrating records from MongoDB were not properly switching the metadata types. This has been resolved by requiring the Store to be passed to all() and retrieve() in the Persister.