### PR TITLE
Abstracted Persistence Layer to Support Multiple Persisters

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/AbstractFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/AbstractFileDriver.php
@@ -4,6 +4,7 @@ namespace Actinoids\Modlr\RestOdm\Metadata\Driver;
 
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 use Actinoids\Modlr\RestOdm\Exception\MetadataException;
+use Actinoids\Modlr\RestOdm\Persister\PersisterManager;
 
 /**
  * Abstract metadata file driver.
@@ -34,14 +35,23 @@ abstract class AbstractFileDriver implements DriverInterface
     private $allEntityTypes;
 
     /**
+     * The Persister Manager service.
+     * Used to determine the Persistence Metadata to use for the model.
+     *
+     * @var PersisterManager
+     */
+    private $persisterManager;
+
+    /**
      * Constructor.
      *
      * @param   FileLocatorInterface    $fileLocator
      * @param   Validator               $validator
      */
-    public function __construct(FileLocatorInterface $fileLocator)
+    public function __construct(FileLocatorInterface $fileLocator, PersisterManager $persisterManager)
     {
         $this->fileLocator = $fileLocator;
+        $this->persisterManager = $persisterManager;
     }
 
     /**
@@ -76,6 +86,14 @@ abstract class AbstractFileDriver implements DriverInterface
             throw MetadataException::fatalDriverError($type, sprintf('No mapping file was found.', $path));
         }
         return $path;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPersistenceMetadataFactory($persisterKey)
+    {
+        return $this->persisterManager->getPersister($persisterKey)->getPersistenceMetadataFactory();
     }
 
     /**

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/DriverInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/DriverInterface.php
@@ -28,6 +28,14 @@ interface DriverInterface
     public function getAllTypeNames();
 
     /**
+     * Gets the persistence metadata factory service, based on a persister key.
+     *
+     * @param   string  $persisterKey
+     * @return  \Actinoids\Modlr\RestOdm\Metadata\Interfaces\PersistenceMetadataFactoryInterface
+     */
+    public function getPersistenceMetadataFactory($persisterKey);
+
+    /**
      * Gets the type hierarchy (via extension) for an entity type.
      * Is recursive.
      *

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
@@ -129,11 +129,11 @@ class YamlFileDriver extends AbstractFileDriver
      *
      * @todo    Inject type manager and validate data type. Or should this happen later???
      * @todo    Add support for complex attributes, like arrays and objects.
-     * @param   Metadata\AttributeInterface $metadata
+     * @param   Metadata\Interfaces\AttributeInterface $metadata
      * @param   array                       $attrMapping
      * @return  Metadata\EntityMetadata
      */
-    protected function setAttributes(Metadata\AttributeInterface $metadata, array $attrMapping)
+    protected function setAttributes(Metadata\Interfaces\AttributeInterface $metadata, array $attrMapping)
     {
         foreach ($attrMapping as $key => $mapping) {
             if (!is_array($mapping)) {

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
@@ -30,14 +30,6 @@ class YamlFileDriver extends AbstractFileDriver
 
         $metadata = new Metadata\EntityMetadata($type);
 
-        if (isset($mapping['entity']['db'])) {
-            $metadata->db = $mapping['entity']['db'];
-        }
-
-        if (isset($mapping['entity']['collection'])) {
-            $metadata->collection = $mapping['entity']['collection'];
-        }
-
         if (isset($mapping['entity']['abstract'])) {
             $metadata->setAbstract(true);
         }
@@ -51,6 +43,7 @@ class YamlFileDriver extends AbstractFileDriver
             $metadata->extends = $mapping['entity']['extends'];
         }
 
+        $this->setPersistence($metadata, $mapping['entity']['persistence']);
         $this->setAttributes($metadata, $mapping['attributes']);
         $this->setRelationships($metadata, $mapping['relationships']);
         return $metadata;
@@ -122,6 +115,33 @@ class YamlFileDriver extends AbstractFileDriver
             throw MetadataException::fatalDriverError($type, sprintf('No type key was found at the beginning of the YAML file. Expected "%s"', $type));
         }
         return $this->mappings[$type] = $this->setDefaults($contents[$type]);
+    }
+
+    /**
+     * Sets the entity persistence metadata from the metadata mapping.
+     *
+     * @param   Metadata\EntityMetadata     $metadata
+     * @param   array                       $mapping
+     * @return  Metadata\EntityMetadata
+     */
+    protected function setPersistence(Metadata\EntityMetadata $metadata, array $mapping)
+    {
+        $persisterKey = isset($mapping['key']) ? $mapping['key'] : null;
+        $factory = $this->getPersistenceMetadataFactory($persisterKey);
+
+        $persistence = $factory->getNewInstance();
+        $persistence->persisterKey = $persisterKey;
+
+        if (isset($mapping['db'])) {
+            $persistence->db = $mapping['db'];
+        }
+
+        if (isset($mapping['collection'])) {
+            $persistence->collection = $mapping['collection'];
+        }
+
+        $metadata->setPersistence($persistence);
+        return $metadata;
     }
 
     /**
@@ -221,6 +241,16 @@ class YamlFileDriver extends AbstractFileDriver
                 $mapping[$key] = [];
             }
         }
+
+        if (!isset($mapping['entity']['persistence'])) {
+            $mapping['entity']['persistence'] = [];
+        }
+
+        if (!isset($mapping['entity']['persistence']['key'])) {
+            // @todo Should this be defaulted here, or handled differently?
+            $mapping['entity']['persistence']['key'] = 'mongodb';
+        }
+
         return $mapping;
     }
 

--- a/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
@@ -5,6 +5,7 @@ namespace Actinoids\Modlr\RestOdm\Metadata;
 use Actinoids\Modlr\RestOdm\Exception\MetadataException;
 use Actinoids\Modlr\RestOdm\Metadata\Interfaces\AttributeInterface;
 use Actinoids\Modlr\RestOdm\Metadata\Interfaces\MergeableInterface;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\PersistenceInterface;
 
 /**
  * Defines the metadata for an entity (e.g. a database object).
@@ -26,29 +27,6 @@ class EntityMetadata implements AttributeInterface, MergeableInterface
      * @var string
      */
     public $type;
-
-    /**
-     * The database name.
-     *
-     * @var string
-     */
-    public $db;
-
-    /**
-     * The collection name.
-     *
-     * @var string
-     */
-    public $collection;
-
-    /**
-     * The ID strategy to use.
-     * Currently object is the only valid choice.
-     *
-     * @todo Implement an auto-increment integer id strategy.
-     * @var string
-     */
-    public $idStrategy = 'object';
 
     /**
      * Whether this class is considered polymorphic.
@@ -76,6 +54,13 @@ class EntityMetadata implements AttributeInterface, MergeableInterface
      * @var bool
      */
     public $abstract = false;
+
+    /**
+     * The persistence metadata for this entity.
+     *
+     * @param PersistenceInterface
+     */
+    public $persistence;
 
     /**
      * All attribute fields assigned to this entity.
@@ -117,13 +102,15 @@ class EntityMetadata implements AttributeInterface, MergeableInterface
     public function merge(MergeableInterface $metadata)
     {
         $this->setType($metadata->type);
-        // @todo Remove these if necessary.
         $this->setPolymorphic($metadata->isPolymorphic());
         $this->setAbstract($metadata->isAbstract());
         $this->extends = $metadata->extends;
         $this->ownedTypes = $metadata->ownedTypes;
+
+        $this->persistence->merge($metadata->persistence);
         $this->mergeAttributes($metadata->getAttributes());
         $this->mergeRelationships($metadata->getRelationships());
+
         // @todo Implement this.
         // $this->mergeMixins($metadata->getMixins());
         return $this;
@@ -299,6 +286,18 @@ class EntityMetadata implements AttributeInterface, MergeableInterface
             return null;
         }
         return $this->attributes[$key];
+    }
+
+    /**
+     * Sets the persistence metadata for this entity.
+     *
+     * @param   PersisterInterface  $persistence
+     * @return  self
+     */
+    public function setPersistence(PersistenceInterface $persistence)
+    {
+        $this->persistence = $persistence;
+        return $this;
     }
 
     /**

--- a/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
@@ -3,6 +3,8 @@
 namespace Actinoids\Modlr\RestOdm\Metadata;
 
 use Actinoids\Modlr\RestOdm\Exception\MetadataException;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\AttributeInterface;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\MergeableInterface;
 
 /**
  * Defines the metadata for an entity (e.g. a database object).
@@ -10,7 +12,7 @@ use Actinoids\Modlr\RestOdm\Exception\MetadataException;
  *
  * @author Jacob Bare <jacob.bare@gmail.com>
  */
-class EntityMetadata implements AttributeInterface
+class EntityMetadata implements AttributeInterface, MergeableInterface
 {
     /**
      * The id key name and type.
@@ -110,14 +112,9 @@ class EntityMetadata implements AttributeInterface
     }
 
     /**
-     * Merges an EntityMetadata instance with this instance.
-     * For use with entity class extension.
-     * Only merge items where you want the child class to override the parent!
-     *
-     * @param   EntityMetadata  $metadata
-     * @return  self
+     * {@inheritDoc}
      */
-    public function merge(EntityMetadata $metadata)
+    public function merge(MergeableInterface $metadata)
     {
         $this->setType($metadata->type);
         // @todo Remove these if necessary.

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/AttributeInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/AttributeInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Actinoids\Modlr\RestOdm\Metadata;
+namespace Actinoids\Modlr\RestOdm\Metadata\Interfaces;
+
+use Actinoids\Modlr\RestOdm\Metadata\AttributeMetadata;
 
 /**
  * Interface for Metadata objects containing attributes.

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/MergeableInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/MergeableInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Metadata\Interfaces;
+
+/**
+ * Defines the metadata instances that support merging.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+interface MergeableInterface
+{
+    /**
+     * Merges a Mergeable instance with this instance.
+     * For use with entity class extension.
+     * Only merge items where you want the child class to override the parent!
+     *
+     * @param   MergeableInterface  $metadata
+     * @return  self
+     */
+    public function merge(MergeableInterface $metadata);
+}

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceInterface.php
@@ -12,4 +12,10 @@ namespace Actinoids\Modlr\RestOdm\Metadata\Interfaces;
  */
 interface PersistenceInterface extends MergeableInterface
 {
+    /**
+     * Returns the persister key for this persistence metadata.
+     *
+     * @return  string
+     */
+    public function getPersisterKey();
 }

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Metadata\Interfaces;
+
+/**
+ * Defines the persistence metadata for an entity (e.g. a database object).
+ * Should be loaded using the MetadataFactory, not instantiated directly.
+ * Contains information about the database schema, such as db/collection/table names, indexes, etc.
+ * Each implementing class must define it's own merging criteria, and handle it's own properties/methods.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+interface PersistenceInterface extends MergeableInterface
+{
+}

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceMetadataFactoryInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Interfaces/PersistenceMetadataFactoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Metadata\Interfaces;
+
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Creates Persistence Metadata instances in the implementing format.
+ * Is used by the metadata driver and/or factory for creating new instances and validation.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+interface PersistenceMetadataFactoryInterface
+{
+    /**
+     * Gets a new and empty Persistence Metadata object.
+     *
+     * @return  PersistenceInterface
+     */
+    public function getNewInstance();
+
+    /**
+     * Handles additional metadata operations on the Factory load.
+     *
+     * @param   EntityMetadata
+     */
+    public function handleLoad(EntityMetadata $metadata);
+
+    /**
+     * Handles additional validation specific to this persister.
+     *
+     * @param   EntityMetadata
+     * @throws  \Actinoids\Modlr\RestOdm\Exception\MetadataException On invalid metadata.
+     */
+    public function handleValidate(EntityMetadata $metadata);
+}

--- a/src/Actinoids/Modlr/RestOdm/Metadata/MetadataFactory.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/MetadataFactory.php
@@ -129,9 +129,6 @@ class MetadataFactory implements MetadataFactoryInterface
 
             // Load from driver source
             $loaded = $this->driver->loadMetadataForType($hierType);
-            if (null === $loaded->collection) {
-                $loaded->collection = $loaded->type;
-            }
 
             if (null === $loaded) {
                 throw MetadataException::mappingNotFound($type);
@@ -139,6 +136,13 @@ class MetadataFactory implements MetadataFactoryInterface
 
             // Validate the metadata object.
             $this->entityUtil->validateMetadata($hierType, $loaded, $this);
+
+            // Handle persistence specific loading and validation.
+            $persisterKey = $loaded->persistence->getPersisterKey();
+            $persistenceFactory = $this->driver->getPersistenceMetadataFactory($persisterKey);
+
+            $persistenceFactory->handleLoad($loaded);
+            $persistenceFactory->handleValidate($loaded);
 
             $this->mergeMetadata($metadata, $loaded);
             $this->doPutMetadata($loaded);

--- a/src/Actinoids/Modlr/RestOdm/Persister/MongoDBPersister.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/MongoDBPersister.php
@@ -20,6 +20,23 @@ class MongoDBPersister implements PersisterInterface
 {
     const IDENTIFIER_KEY    = '_id';
     const POLYMORPHIC_KEY   = '_type';
+    const PERSISTER_KEY     = 'mongodb';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPersisterKey()
+    {
+        return self::PERSISTER_KEY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPersistenceMetadataClass()
+    {
+        return 'Actinoids\Modlr\RestOdm\Persister\MongoDb\PersistenceMetadata';
+    }
 
     /**
      * The Doctine MongoDB connection.

--- a/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/PersistenceMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/PersistenceMetadata.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister\MongoDb;
+
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\MergeableInterface;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\PersistenceInterface;
+
+/**
+ * Defines the MongoDB persistence metadata for an entity (e.g. a database object).
+ * Should be loaded using the MetadataFactory, not instantiated directly.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class PersistenceMetadata implements PersistenceInterface
+{
+    /**
+     * The persister key.
+     *
+     * @var string
+     */
+    public $persisterKey;
+
+    /**
+     * The database name.
+     *
+     * @var string
+     */
+    public $db;
+
+    /**
+     * The collection name.
+     *
+     * @var string
+     */
+    public $collection;
+
+    /**
+     * The ID strategy to use.
+     * Currently object is the only valid choice.
+     *
+     * @todo Implement an auto-increment integer id strategy.
+     * @var string
+     */
+    public $idStrategy = 'object';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPersisterKey()
+    {
+        return $this->persisterKey;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function merge(MergeableInterface $metadata)
+    {
+        return $this;
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/PersistenceMetadataFactory.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/PersistenceMetadataFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister\MongoDb;
+
+use Actinoids\Modlr\RestOdm\Util\EntityUtility;
+use Actinoids\Modlr\RestOdm\Exception\MetadataException;
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\PersistenceMetadataFactoryInterface;
+
+/**
+ * Creates MongoDb Persistence Metadata instances for use with metadata drivers.
+ * Is also responsible for validating persistence object.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class PersistenceMetadataFactory implements PersistenceMetadataFactoryInterface
+{
+    /**
+     * @var EntityUtility
+     */
+    private $entityUtil;
+
+    /**
+     * Constructor.
+     *
+     * @param   EntityUtility   $entityUtl
+     */
+    public function __construct(EntityUtility $entityUtil)
+    {
+        $this->entityUtil = $entityUtil;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNewInstance()
+    {
+        return new PersistenceMetadata();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handleLoad(EntityMetadata $metadata)
+    {
+        if (null === $metadata->persistence->collection) {
+            $metadata->persistence->collection = $metadata->type;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handleValidate(EntityMetadata $metadata)
+    {
+        $persistence = $metadata->persistence;
+
+        $validIdStrategies = ['object'];
+        if (!in_array($persistence->idStrategy, $validIdStrategies)) {
+            throw MetadataException::invalidMetadata($metadata->type, sprintf('The persistence id strategy "%s" is invalid. Valid types are "%s"', $persistence->idStrategy, implode('", "', $validIdStrategies)));
+        }
+
+        if (false === $metadata->isChildEntity() && (empty($persistence->db) || empty($persistence->collection))) {
+            throw MetadataException::invalidMetadata($metadata->type, 'The persistence database and collection names cannot be empty.');
+        }
+
+        if (false === $this->entityUtil->isEntityTypeValid($persistence->collection)) {
+            throw MetadataException::invalidMetadata(
+                $metadata->type,
+                sprintf('The entity persistence collection "%s" is invalid based on the configured name format "%s"',
+                        $persistence->collection,
+                        $this->entityUtil->getRestConfig()->getEntityFormat()
+                )
+            );
+        }
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/Persister.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/MongoDb/Persister.php
@@ -1,14 +1,16 @@
 <?php
 
-namespace Actinoids\Modlr\RestOdm\Persister;
+namespace Actinoids\Modlr\RestOdm\Persister\MongoDb;
 
-use Actinoids\Modlr\RestOdm\Persister\MongoDb\PersistenceMetadataFactory;
 use Actinoids\Modlr\RestOdm\Store\Store;
 use Actinoids\Modlr\RestOdm\Models\Model;
 use Actinoids\Modlr\RestOdm\Models\Collection;
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 use Actinoids\Modlr\RestOdm\Metadata\AttributeMetadata;
 use Actinoids\Modlr\RestOdm\Metadata\RelationshipMetadata;
+use Actinoids\Modlr\RestOdm\Persister\PersisterInterface;
+use Actinoids\Modlr\RestOdm\Persister\PersisterException;
+use Actinoids\Modlr\RestOdm\Persister\Record;
 use Doctrine\MongoDB\Connection;
 use \MongoId;
 
@@ -17,7 +19,7 @@ use \MongoId;
  *
  * @author Jacob Bare <jacob.bare@gmail.com>
  */
-class MongoDBPersister implements PersisterInterface
+class Persister implements PersisterInterface
 {
     const IDENTIFIER_KEY    = '_id';
     const POLYMORPHIC_KEY   = '_type';

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Actinoids\Modlr\RestOdm\Store;
+namespace Actinoids\Modlr\RestOdm\Persister;
 
 use Actinoids\Modlr\RestOdm\Exception\AbstractHttpException;
 

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterException.php
@@ -36,6 +36,18 @@ class PersisterException extends AbstractHttpException
         );
     }
 
+    public static function persisterNotFound($key)
+    {
+        return new self(
+            sprintf(
+                'Unable to handle database operations. No persister found for type "%s"',
+                $key
+            ),
+            500,
+            __FUNCTION__
+        );
+    }
+
     public static function nyi($featureDescription)
     {
         return new self(

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
@@ -5,6 +5,7 @@ namespace Actinoids\Modlr\RestOdm\Persister;
 use Actinoids\Modlr\RestOdm\Store\Store;
 use Actinoids\Modlr\RestOdm\Models\Model;
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+use Actinoids\Modlr\RestOdm\Metadata\Interfaces\PersistenceMetadataFactoryInterface;
 
 /**
  * Defines the persister service implementation for persisting models to a data layer.
@@ -23,11 +24,11 @@ interface PersisterInterface
     public function getPersisterKey();
 
     /**
-     * Gets the persistence metadata class name for creating PersistenceInterface instances.
+     * Gets the persistence metadata factory for creating PersistenceInterface instances.
      *
-     * @return  string
+     * @return  PersistenceMetadataFactoryInterface
      */
-    public function getPersistenceMetadataClass();
+    public function getPersistenceMetadataFactory();
 
     /**
      * Gets all records for the specified type, optinally filtered by a set of identifiers.

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterInterface.php
@@ -14,6 +14,22 @@ use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 interface PersisterInterface
 {
     /**
+     * Gets the key name for this persister.
+     * Is used to uniquely indentify this persistence type by the persister manager.
+     * Is also the type key for the persistence metadata layer.
+     *
+     * @return  string
+     */
+    public function getPersisterKey();
+
+    /**
+     * Gets the persistence metadata class name for creating PersistenceInterface instances.
+     *
+     * @return  string
+     */
+    public function getPersistenceMetadataClass();
+
+    /**
      * Gets all records for the specified type, optinally filtered by a set of identifiers.
      *
      * @todo    Implement sorting and pagination (limit/skip).

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterManager.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterManager.php
@@ -41,7 +41,7 @@ class PersisterManager
      */
     public function getPersister($key)
     {
-        if (false === $this->hasPersister($key)) {
+        if (empty($key) || false === $this->hasPersister($key)) {
             throw PersisterException::persisterNotFound($key);
         }
         return $this->persisters[$key];

--- a/src/Actinoids/Modlr/RestOdm/Persister/PersisterManager.php
+++ b/src/Actinoids/Modlr/RestOdm/Persister/PersisterManager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Actinoids\Modlr\RestOdm\Persister;
+
+use Actinoids\Modlr\RestOdm\Store\Store;
+use Actinoids\Modlr\RestOdm\Models\Model;
+use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
+
+/**
+ * Registers all available Persister services by key.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class PersisterManager
+{
+    /**
+     * All registered Persister services.
+     *
+     * @var PersisterInterface[]
+     */
+    private $persisters = [];
+
+    /**
+     * Adds/registers a Persister service to the manager.
+     *
+     * @param   PersisterInterface  $persister
+     * @return  self
+     */
+    public function addPersister(PersisterInterface $persister)
+    {
+        $this->persisters[$persister->getPersisterKey()] = $persister;
+        return $this;
+    }
+
+    /**
+     * Gets a Persister service by key.
+     *
+     * @param   string  $key
+     * @return  PersisterInterface
+     * @throws  PersisterException  If the service was not found.
+     */
+    public function getPersister($key)
+    {
+        if (false === $this->hasPersister($key)) {
+            throw PersisterException::persisterNotFound($key);
+        }
+        return $this->persisters[$key];
+    }
+
+    /**
+     * Determines if a Persister exists.
+     *
+     * @param   string  $key
+     * @return  bool
+     */
+    public function hasPersister($key)
+    {
+        return isset($this->persisters[$key]);
+    }
+}

--- a/src/Actinoids/Modlr/RestOdm/Store/Store.php
+++ b/src/Actinoids/Modlr/RestOdm/Store/Store.php
@@ -10,6 +10,7 @@ use Actinoids\Modlr\RestOdm\Metadata\MetadataFactory;
 use Actinoids\Modlr\RestOdm\Metadata\EntityMetadata;
 use Actinoids\Modlr\RestOdm\Metadata\RelationshipMetadata;
 use Actinoids\Modlr\RestOdm\Persister\PersisterInterface;
+use Actinoids\Modlr\RestOdm\Persister\PersisterManager;
 use Actinoids\Modlr\RestOdm\Persister\Record;
 use Actinoids\Modlr\RestOdm\DataTypes\TypeFactory;
 use Actinoids\Modlr\RestOdm\Events\EventDispatcher;
@@ -33,12 +34,12 @@ class Store
     private $typeFactory;
 
     /**
-     * The persister for retrieve and saving records to the database layer.
+     * The persister manager.
+     * Retrieves the appropriate persister for saving records to the database layer.
      *
-     * @todo Eventually this should be replaced by a persister manager and not injected directly.
-     * @var  PersisterInterface
+     * @var  PersisterManager
      */
-    private $persister;
+    private $persisterManager;
 
     /**
      * Contains all models currently loaded in memory.
@@ -58,12 +59,12 @@ class Store
      * Constructor.
      *
      * @param   MetadataFactory     $mf
-     * @param   PersisterInterface  $persister
+     * @param   PersisterManager    $persisterManager
      */
-    public function __construct(MetadataFactory $mf, PersisterInterface $persister, TypeFactory $typeFactory, EventDispatcher $dispatcher)
+    public function __construct(MetadataFactory $mf, PersisterManager $persisterManager, TypeFactory $typeFactory, EventDispatcher $dispatcher)
     {
         $this->mf = $mf;
-        $this->persister = $persister;
+        $this->persisterManager = $persisterManager;
         $this->typeFactory = $typeFactory;
         $this->dispatcher = $dispatcher;
         $this->cache = new Cache();
@@ -479,15 +480,13 @@ class Store
     /**
      * Determines the persister to use for the provided model key.
      *
-     * @todo    The persister should NOT be injected directly, but should have a persister manager service.
-     * @todo    Instead, a persister should be chosen based on the metadata for the provided type.
-     * @todo    Should throw an exception if persister metadata was unable to be found, or the service doesn't exist.
      * @param   string  $typeKey    The model type key.
      * @return  PersisterInterface
      */
     protected function getPersisterFor($typeKey)
     {
-        return $this->persister;
+        $metadata = $this->getMetadataForType($typeKey);
+        return $this->persisterManager->getPersister($metadata->persistence->getPersisterKey());
     }
 
     /**

--- a/src/Actinoids/Modlr/RestOdm/Util/EntityUtility.php
+++ b/src/Actinoids/Modlr/RestOdm/Util/EntityUtility.php
@@ -54,6 +54,16 @@ class EntityUtility
     }
 
     /**
+     * Gets the REST configuration object.
+     *
+     * @return  RestConfiguration
+     */
+    public function getRestConfig()
+    {
+        return $this->config;
+    }
+
+    /**
      * Determines if a field key is valid, based on configuration.
      *
      * @param   string  $value
@@ -91,13 +101,8 @@ class EntityUtility
         }
         $this->validateMetadataType($metadata);
 
-        $validIdStrategies = ['object'];
-        if (!in_array($metadata->idStrategy, $validIdStrategies)) {
-            throw MetadataException::invalidMetadata($requestedType, sprintf('The id strategy "%s" is invalid. Valid types are "%s"', $metadata->idStrategy, implode('", "', $validIdStrategies)));
-        }
-
-        if (false === $metadata->isChildEntity() && (empty($metadata->db) || empty($metadata->collection))) {
-            throw MetadataException::invalidMetadata($requestedType, 'The database and collection names cannot be empty.');
+        if (null === $metadata->persistence) {
+            throw MetadataException::invalidMetadata($requestedType, 'No persistence metadata was found. All models must use a persistence layer.');
         }
 
         $this->validateMetadataInheritance($metadata, $mf);
@@ -123,9 +128,6 @@ class EntityUtility
         }
         if (false === $this->isEntityTypeValid($metadata->type)) {
             throw MetadataException::invalidMetadata($metadata->type, sprintf('The entity type is invalid based on the configured name format "%s"', $this->config->getEntityFormat()));
-        }
-        if (false === $this->isEntityTypeValid($metadata->collection)) {
-            throw MetadataException::invalidMetadata($metadata->type, sprintf('The entity collection "%s" is invalid based on the configured name format "%s"', $metadata->collection, $this->config->getEntityFormat()));
         }
         return true;
     }


### PR DESCRIPTION
MongoDB is still the default persister, but Modlr now supports additional persistence engines.

Metadata handling has been updated to reflect this, as well as the Store's ```getPersisterFor``` method.

This is made possible via the ```PersisterManager``` service that support registering multiple persisters. 

The persister is now responsible for returning a Persistence Metadata Factory to create new instances, handle additional MF load functions, and validate the persistence metadata instances - since these processes will be unique for each persistence engine.

MongoDB persistence classes have now been "bundled" under the MongoDb namespace.