### PR TITLE
Added support for model and attribute default values

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Metadata/AttributeMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/AttributeMetadata.php
@@ -18,6 +18,13 @@ class AttributeMetadata extends FieldMetadata
     public $dataType;
 
     /**
+     * The attribute's default value, if set.
+     *
+     * @var mixed
+     */
+    public $defaultValue;
+
+    /**
      * Constructor.
      *
      * @param   string  $key        The attribute field key.
@@ -28,5 +35,15 @@ class AttributeMetadata extends FieldMetadata
     {
         parent::__construct($key, $mixin);
         $this->dataType = $dataType;
+    }
+
+    /**
+     * Determines if this attribute has a default value.
+     *
+     * @return  bool
+     */
+    public function hasDefaultValue()
+    {
+        null !== $this->defaultValue;
     }
 }

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
@@ -46,6 +46,10 @@ final class YamlFileDriver extends AbstractFileDriver
             $metadata->extends = $mapping['entity']['extends'];
         }
 
+        if (isset($mapping['entity']['defaultValues']) && is_array($mapping['entity']['defaultValues'])) {
+            $metadata->defaultValues = $mapping['entity']['defaultValues'];
+        }
+
         $this->setPersistence($metadata, $mapping['entity']['persistence']);
         $this->setAttributes($metadata, $mapping['attributes']);
         $this->setRelationships($metadata, $mapping['relationships']);
@@ -188,6 +192,10 @@ final class YamlFileDriver extends AbstractFileDriver
             // @todo Handle complex attribute types.
             if (isset($mapping['description'])) {
                 $attribute->description = $mapping['description'];
+            }
+
+            if (isset($mapping['defaultValue'])) {
+                $attribute->defaultValue = $mapping['defaultValue'];
             }
 
             $metadata->addAttribute($attribute);

--- a/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/EntityMetadata.php
@@ -42,6 +42,8 @@ class EntityMetadata implements AttributeInterface, RelationshipInterface, Merge
     /**
      * Child entity types this entity owns.
      * Only used for polymorphic entities.
+     *
+     * @var array
      */
     public $ownedTypes = [];
 
@@ -52,7 +54,7 @@ class EntityMetadata implements AttributeInterface, RelationshipInterface, Merge
      */
     public $extends;
 
-     /**
+    /**
      * Whether this class is abstract.
      *
      * @var bool
@@ -60,16 +62,23 @@ class EntityMetadata implements AttributeInterface, RelationshipInterface, Merge
     public $abstract = false;
 
     /**
+     * An array of attribute default values for this model.
+     * Keyed by field name.
+     *
+     * @var array
+     */
+    public $defaultValues = [];
+
+    /**
      * The persistence metadata for this entity.
      *
-     * @param PersistenceInterface
+     * @var PersistenceInterface
      */
     public $persistence;
 
     /**
      * All mixins assigned to this entity.
      *
-     * @todo    Implement this.
      * @var     MixinMetadata[]
      */
     public $mixins = [];
@@ -132,6 +141,7 @@ class EntityMetadata implements AttributeInterface, RelationshipInterface, Merge
         $this->setAbstract($metadata->isAbstract());
         $this->extends = $metadata->extends;
         $this->ownedTypes = $metadata->ownedTypes;
+        $this->defaultValues = array_merge($this->defaultValues, $metadata->defaultValues);
 
         $this->persistence->merge($metadata->persistence);
         $this->mergeAttributes($metadata->getAttributes());

--- a/src/Actinoids/Modlr/RestOdm/Models/Model.php
+++ b/src/Actinoids/Modlr/RestOdm/Models/Model.php
@@ -558,6 +558,7 @@ class Model
      */
     public function apply(array $properties)
     {
+        $properties = $this->applyDefaultAttrValues($properties);
         foreach ($properties as $key => $value) {
             if (true === $this->isAttribute($key)) {
                 $this->set($key, $value);
@@ -608,6 +609,7 @@ class Model
         $attributes = [];
 
         if (null !== $record) {
+            $attributes = $this->applyDefaultAttrValues($attributes);
             foreach ($record->getProperties() as $key => $value) {
                 if (true === $this->isAttribute($key)) {
                     // Load attribute.
@@ -639,6 +641,29 @@ class Model
         $this->hasManyRelationships = (null === $this->hasManyRelationships) ? new Relationships\HasMany($hasMany) : $this->hasManyRelationships->replace($hasMany);
         $this->doDirtyCheck();
         return $this;
+    }
+
+    /**
+     * Applies default attribute values from metadata, if set.
+     *
+     * @param   array   $attributes     The attributes to apply the defaults to.
+     * @return  array
+     */
+    protected function applyDefaultAttrValues(array $attributes = [])
+    {
+        // Set defaults for each attribute.
+        foreach ($this->getMetadata()->getAttributes() as $key => $attrMeta) {
+            if (!isset($attrMeta->defaultValue)) {
+                continue;
+            }
+            $attributes[$key] = $this->convertAttributeValue($key, $attrMeta->defaultValue);
+        }
+
+        // Set defaults for the entire entity.
+        foreach ($this->getMetadata()->defaultValues as $key => $value) {
+            $attributes[$key] = $this->convertAttributeValue($key, $value);
+        }
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
Default values can now be set at the entity/model level, or per attribute.

The YAML driver has been updated to support this via ```[modelTypeKey].entity.defaultValues.[attrKey]: [attrValue]``` and ```[modelTypeKey].attributes.[attrKey].defaultValue: [attrValue]```