### PR TITLE
Added support for calculated attributes

### DIFF
--- a/src/Actinoids/Modlr/RestOdm/Metadata/AttributeMetadata.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/AttributeMetadata.php
@@ -25,6 +25,16 @@ class AttributeMetadata extends FieldMetadata
     public $defaultValue;
 
     /**
+     * Contains the caculated field parameters.
+     *
+     * @var array
+     */
+    public $calculated = [
+        'class'     => null,
+        'method'    => null,
+    ];
+
+    /**
      * Constructor.
      *
      * @param   string  $key        The attribute field key.
@@ -45,5 +55,15 @@ class AttributeMetadata extends FieldMetadata
     public function hasDefaultValue()
     {
         null !== $this->defaultValue;
+    }
+
+    /**
+     * Determines if this attribute is calculated.
+     *
+     * @return  bool
+     */
+    public function isCalculated()
+    {
+        return null !== $this->calculated['class'] && null !== $this->calculated['method'];
     }
 }

--- a/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
+++ b/src/Actinoids/Modlr/RestOdm/Metadata/Driver/YamlFileDriver.php
@@ -170,10 +170,9 @@ final class YamlFileDriver extends AbstractFileDriver
     /**
      * Sets the entity attribute metadata from the metadata mapping.
      *
-     * @todo    Inject type manager and validate data type. Or should this happen later???
      * @todo    Add support for complex attributes, like arrays and objects.
-     * @param   Metadata\Interfaces\AttributeInterface $metadata
-     * @param   array                       $attrMapping
+     * @param   Metadata\Interfaces\AttributeInterface  $metadata
+     * @param   array                                   $attrMapping
      * @return  Metadata\EntityMetadata
      */
     protected function setAttributes(Metadata\Interfaces\AttributeInterface $metadata, array $attrMapping)
@@ -196,6 +195,14 @@ final class YamlFileDriver extends AbstractFileDriver
 
             if (isset($mapping['defaultValue'])) {
                 $attribute->defaultValue = $mapping['defaultValue'];
+            }
+
+            if (isset($mapping['calculated']) && is_array($mapping['calculated'])) {
+                $calculated = $mapping['calculated'];
+                if (isset($calculated['class']) && isset($calculated['method'])) {
+                    $attribute->calculated['class']  =  $calculated['class'];
+                    $attribute->calculated['method'] =  $calculated['method'];
+                }
             }
 
             $metadata->addAttribute($attribute);

--- a/src/Actinoids/Modlr/RestOdm/Util/EntityUtility.php
+++ b/src/Actinoids/Modlr/RestOdm/Util/EntityUtility.php
@@ -215,6 +215,12 @@ class EntityUtility
             if (in_array($attribute->dataType, $todo)) {
                 throw MetadataException::invalidMetadata($metadata->type, 'NYI: Object and array attribute types still need expanding!!');
             }
+
+            if (true === $attribute->isCalculated()) {
+                if (false === class_exists($attribute->calculated['class']) || false === method_exists($attribute->calculated['class'], $attribute->calculated['method'])) {
+                    throw MetadataException::invalidMetadata($metadata->type, sprintf('The attribute field "%s" is calculated, but was unable to find method "%s:%s"', $attribute->key, $attribute->calculated['class'], $attribute->calculated['method']));
+                }
+            }
         }
         return true;
     }


### PR DESCRIPTION
Models can now have calculated attributes. A calculated attribute is one whose value is not persisted, and is calculated using values from other attributes and/or relationships on the Model.

This is accomplished by setting a class name and callback method. When the attribute is accessed, this method will be called to generate the value. The method must be set as ```static``` in the owning class, and must handle one argument: ```Model $model```

The YAML metadata driver supports this by setting ```class``` and ```method``` under ```[modelTypeKey].attributes.[attrKey].calculated```